### PR TITLE
🔧  pre-commit configuration to remove ruff-check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.6
     hooks:
-      - id: ruff-check
-        args: [--fix]
+      # GitHub Actions runners have ruff installed, so we only need to format here.
+      # - id: ruff-check
+      #   args: [--fix]
       - id: ruff-format


### PR DESCRIPTION
## 変更内容
- pre-commit時のチェックをフォーマッターのみに変更

## 変更理由
- 作業中の内容をコミットする際は型チェックが邪魔になるため

